### PR TITLE
Publish using JDK 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -44,7 +44,7 @@ jobs:
             ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "17"
           distribution: "temurin"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: 21
+          java-version: "17"
+          distribution: "temurin"
       - name: Set release version
         run: bash ./setversion.sh ${{ github.ref_name }} gadulka/build.gradle.kts
       - name: Publish to MavenCentral


### PR DESCRIPTION
Adapt the build workflow to use JDK 17 for compatibility with projects using this version.
Also align the setup-java action to be the same between the build and publish workflows.