### PR TITLE
Fix player release

### DIFF
--- a/gadulka/src/wasmJsMain/kotlin/GadulkaAudioPlayer.wasmJs.kt
+++ b/gadulka/src/wasmJsMain/kotlin/GadulkaAudioPlayer.wasmJs.kt
@@ -38,6 +38,7 @@ actual class GadulkaPlayer(val htmlId: String) {
     actual fun release() {
         val playerEl = getPlayerElement()
         playerEl?.pause()
+        playerEl?.remove()
     }
 
     private fun getPlayerElement(): HTMLAudioElement? {


### PR DESCRIPTION
I suspect the line got lost somewhere since your function already "removes the player element from the DOM."

Without the fix I am not able to play different songs with a single player instance under the same htmlId