### PR TITLE
Upgrade to Kotlin 2.1.0

### DIFF
--- a/gadulka/build.gradle.kts
+++ b/gadulka/build.gradle.kts
@@ -1,7 +1,6 @@
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -25,11 +24,13 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
-    @OptIn(ExperimentalWasmDsl::class)
+
+    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
     wasmJs {
         browser()
         binaries.executable()
     }
+
 
     sourceSets {
         val commonMain by getting {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 agp = "8.5.2"
-kotlin = "2.0.21"
+kotlin = "2.1.0"
 android-minSdk = "24"
 android-compileSdk = "34"
-media3_version = "1.4.1"
+media3_version = "1.5.1"
 kotlinx-browser = "0.3"
 
 [libraries]


### PR DESCRIPTION
This PR upgrades the library to [Kotlin 2.1.0](https://kotlinlang.org/docs/whatsnew21.html#language) and the media3 dependency to version 1.5.