### PR TITLE
Kotlin 2.1.21, JDK 21, JavaFX 23

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,10 +28,10 @@ jobs:
           path: |
             ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@799ee7c97e9721ef38d1a7e8486c39753b9d6102
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
       - name: Dokka Build
         run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,10 +45,10 @@ jobs:
           path: |
             ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@799ee7c97e9721ef38d1a7e8486c39753b9d6102
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
       - name: Build with Gradle
         uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
@@ -70,10 +70,10 @@ jobs:
           path: |
             ~/.konan
           key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@799ee7c97e9721ef38d1a7e8486c39753b9d6102
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
       - name: WASM Example Build
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@85e6279cec87321a52edac9c87bce653a07cf6c2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@799ee7c97e9721ef38d1a7e8486c39753b9d6102
         with:
-          java-version: "17"
+          java-version: "21"
           distribution: "temurin"
       - name: Set release version
         run: bash ./setversion.sh ${{ github.ref_name }} gadulka/build.gradle.kts

--- a/README.md
+++ b/README.md
@@ -111,6 +111,29 @@ fun AudioPlayer() {
 Additional methods to control volume, position and playback rate are [also available](https://gadulka.iamkonstantin.eu).
 
 
+Gadulka links against but doesn't bundle JavaFX. You may need to adapt your gradle file to add the corresponding dependencies e.g.:
+
+```kotlin
+val jvmMain by getting {
+    dependencies {
+        val fxSuffix = when (osdetector.classifier) {
+            "linux-x86_64" -> "linux"
+            "linux-aarch_64" -> "linux-aarch64"
+            "windows-x86_64" -> "win"
+            "osx-x86_64" -> "mac"
+            "osx-aarch_64" -> "mac-aarch64"
+            else -> throw IllegalStateException("Unknown OS: ${osdetector.classifier}")
+        }
+        implementation("org.openjfx:javafx-base:23:${fxSuffix}")
+        implementation("org.openjfx:javafx-graphics:23:${fxSuffix}")
+        implementation("org.openjfx:javafx-controls:23:${fxSuffix}")
+        implementation("org.openjfx:javafx-swing:23:${fxSuffix}")
+        implementation("org.openjfx:javafx-web:23:${fxSuffix}")
+        implementation("org.openjfx:javafx-media:23:${fxSuffix}")
+    }
+}
+```
+
 📖 [Docs](https://gadulka.iamkonstantin.eu)
 
 🍿 [Demo (WASM)](https://gadulka.iamkonstantin.eu/wasm)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ does not provide any UI (this will be up to you). You can read more about my mot
 Gadulka is available from Maven Central at the following coordinates:
 
 ```
-implementation("eu.iamkonstantin.kotlin:gadulka:1.6.3")
+implementation("eu.iamkonstantin.kotlin:gadulka:1.7.0")
 ```
 
 ### Example

--- a/gadulka/build.gradle.kts
+++ b/gadulka/build.gradle.kts
@@ -28,7 +28,7 @@ kotlin {
         publishLibraryVariants("release")
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
+            jvmTarget.set(JvmTarget.JVM_11)
         }
     }
     iosX64()
@@ -60,16 +60,17 @@ kotlin {
                     "linux-x86_64" -> "linux"
                     "linux-aarch_64" -> "linux-aarch64"
                     "windows-x86_64" -> "win"
+                    "windows-aarch_64" -> "win-aarch64"
                     "osx-x86_64" -> "mac"
                     "osx-aarch_64" -> "mac-aarch64"
                     else -> throw IllegalStateException("Unknown OS: ${osdetector.classifier}")
                 }
-                implementation("org.openjfx:javafx-base:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-graphics:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-controls:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-swing:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-web:19:${fxSuffix}")
-                implementation("org.openjfx:javafx-media:19:${fxSuffix}")
+                implementation("org.openjfx:javafx-base:23:${fxSuffix}")
+                implementation("org.openjfx:javafx-graphics:23:${fxSuffix}")
+                implementation("org.openjfx:javafx-controls:23:${fxSuffix}")
+                implementation("org.openjfx:javafx-swing:23:${fxSuffix}")
+                implementation("org.openjfx:javafx-web:23:${fxSuffix}")
+                implementation("org.openjfx:javafx-media:23:${fxSuffix}")
             }
         }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,16 @@
 [versions]
 agp = "8.7.3"
 androidcontextprovider = "1.0.1"
-kotlin = "2.1.20"
-media3_version = "1.5.1"
+kotlin = "2.1.21"
+media3_version = "1.7.1"
 kotlinx-browser = "0.3"
 android-compileSdk = "35"
 android-minSdk = "24"
 android-targetSdk = "35"
-compose-multiplatform = "1.7.3"
+compose-multiplatform = "1.8.1"
 androidx-activityCompose = "1.10.1"
-androidx-appcompat = "1.7.0"
-androidx-constraintlayout = "2.2.1"
-androidx-core-ktx = "1.15.0"
-androidx-espresso-core = "3.6.1"
-androidx-lifecycle = "2.8.4"
-androidx-material = "1.12.0"
-androidx-test-junit = "1.2.1"
-junit = "4.13.2"
-kotlinx-coroutines = "1.10.1"
+androidx-lifecycle = "2.9.0"
+kotlinx-coroutines = "1.10.2"
 dokka = "2.0.0"
 cyclonedx = "2.2.0"
 
@@ -26,14 +19,6 @@ androidcontextprovider = { module = "io.github.kdroidfilter:androidcontextprovid
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 androix-media3-exploplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3_version" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser-wasm-js", version.ref = "kotlinx-browser" }
-kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
-androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-espresso-core" }
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
-androidx-material = { group = "com.google.android.material", name = "material", version.ref = "androidx-material" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activityCompose" }
 androidx-lifecycle-viewmodel = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
- Gadulka now builds against [Kotlin 2.1.21](https://kotlinlang.org/docs/whatsnew2120.html)
- Source code compatibility has been set to JVM_11
- Minimum JDK has been raised from 17 to 21
- JavaFX version has been raised from 19 to 23
- Updated readme to mention the need for linking against JavaFX since we don't bundle this dependency due to license constraints.