### PR TITLE
Fixing issues in #29

### DIFF
--- a/gadulka/src/androidMain/kotlin/GadulkaAudioPlayer.android.kt
+++ b/gadulka/src/androidMain/kotlin/GadulkaAudioPlayer.android.kt
@@ -7,8 +7,10 @@ package eu.iamkonstantin.kotlin.gadulka
 
 import android.content.ContentResolver
 import android.net.Uri
+import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import com.kdroid.androidcontextprovider.ContextProvider
 
@@ -31,8 +33,13 @@ actual class GadulkaPlayer actual constructor() {
         if(mediaPlayer.isCommandAvailable(Player.COMMAND_PLAY_PAUSE)) mediaPlayer.play()
     }
 
+    @OptIn(UnstableApi::class)
     actual fun play() {
-        if(mediaPlayer.isCommandAvailable(Player.COMMAND_PLAY_PAUSE)) mediaPlayer.play()
+        if(mediaPlayer.isCommandAvailable(Player.COMMAND_PLAY_PAUSE)) {
+            if (currentPlayerState() == GadulkaPlayerState.IDLE)
+                seekTo(0)
+            mediaPlayer.play()
+        }
     }
 
 
@@ -61,7 +68,7 @@ actual class GadulkaPlayer actual constructor() {
         return null
     }
 
-    @androidx.media3.common.util.UnstableApi
+    @UnstableApi
     actual fun currentPlayerState(): GadulkaPlayerState? {
         if (mediaPlayer.isReleased) {
             return null


### PR DESCRIPTION
# PR for the fixes in the issue #29.

## What I changed:
### iOS:
- Reuse AVPlayer instance (and play new sources using [`replaceCurrentItemWithPlayerItem`](https://developer.apple.com/documentation/avfoundation/avplayer/replacecurrentitem(with:))) which is more performant.
- Play using an `AVURLAsset` and `AVPlayerItem` (where we can force request the player duration; We now try to get the duration from that `AVPlayerItem`, if that fails we can get it from the underlying `AVURLAsset`)
- Set Buffering state when attaching player events
- Observe [`didPlayToEndTimeNotification`](https://developer.apple.com/documentation/avfoundation/avplayeritem/didplaytoendtimenotification) so we can set `IDLE` after playback is finished
- Observe [`playbackStalledNotification`](https://developer.apple.com/documentation/avfoundation/avplayeritem/playbackstallednotification) so we can set `BUFFERING` state when player stalled
- Keeping last set volume and playback rate (so we can reset them when new playback starts)
- After finishing playback (and the user wants to play again), we seek back to beginning

### Android:
- After finishing playback (and the user wants to play again), we seek back to beginning

### Desktop/JVM
- Set `BUFFERING` state when player stalled
- After playback finishes, call `playerState.stop()`, so the state switches to `IDLE` (also seek to ZERO, if user wants to play again later)
- Fix seeking issues (when player finished, position could exceed duration which led to a undefined state)
- After finishing playback (and the user wants to play again), we seek back to beginning
- Setting playback rate first to 1.0 before the actual value (workaround see [https://stackoverflow.com/a/79324478](https://stackoverflow.com/a/79324478))
- Keeping last set volume and playback rate (so we can reset them when new playback starts)

### WASM:
- Add states for all player events [https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playbackRate](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/playbackRate)
- Fix seeking (WASM player requires seconds, not milliseconds)
- Keeping last set volume and playback rate (so we can reset them when new playback starts)