### PR TITLE
feat: Add an error listener

### DIFF
--- a/gadulka/src/androidMain/kotlin/GadulkaAudioPlayer.android.kt
+++ b/gadulka/src/androidMain/kotlin/GadulkaAudioPlayer.android.kt
@@ -9,6 +9,7 @@ import android.content.ContentResolver
 import android.net.Uri
 import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -18,6 +19,11 @@ import com.kdroid.androidcontextprovider.ContextProvider
 actual class GadulkaPlayer actual constructor() {
 
     private var mediaPlayer = ExoPlayer.Builder(ContextProvider.getContext()).build()
+    private var errorListener: ErrorListener? = null
+
+    init {
+        setup()
+    }
 
     actual fun play(url: String) {
         if (mediaPlayer.isPlaying) {
@@ -119,5 +125,20 @@ actual class GadulkaPlayer actual constructor() {
     actual fun seekTo(time: Long) {
         if (!mediaPlayer.isCommandAvailable(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)) return
         mediaPlayer.seekTo(time)
+    }
+
+    actual fun setOnErrorListener(listener: ErrorListener){
+        errorListener = listener
+    }
+
+    private fun setup() {
+
+        mediaPlayer.addListener(object :Player.Listener{
+            override fun onPlayerError(error: PlaybackException) {
+                errorListener?.onError(error.errorCodeName)
+                super.onPlayerError(error)
+            }
+        })
+
     }
 }

--- a/gadulka/src/commonMain/kotlin/ErrorListener.kt
+++ b/gadulka/src/commonMain/kotlin/ErrorListener.kt
@@ -1,0 +1,5 @@
+package eu.iamkonstantin.kotlin.gadulka
+
+interface ErrorListener {
+    fun onError(message: String?)
+}

--- a/gadulka/src/commonMain/kotlin/GadulkaAudioPlayer.kt
+++ b/gadulka/src/commonMain/kotlin/GadulkaAudioPlayer.kt
@@ -131,6 +131,8 @@ expect class GadulkaPlayer() {
      * @param time The desired playback position in milliseconds. Must be within the duration of the media.
      */
     fun seekTo(time: Long)
+
+    fun setOnErrorListener(listener: ErrorListener)
 }
 
 

--- a/gadulka/src/jvmMain/kotlin/GadulkaAudioPlayer.jvm.kt
+++ b/gadulka/src/jvmMain/kotlin/GadulkaAudioPlayer.jvm.kt
@@ -17,6 +17,7 @@ actual class GadulkaPlayer actual constructor() {
     var playerState: MediaPlayer? = null
     private var lastVolume: Double? = null
     private var lastRate: Double? = null
+    private var errorListener: ErrorListener? = null
 
     init {
         // Ensure JavaFX runtime is initialized
@@ -43,10 +44,12 @@ actual class GadulkaPlayer actual constructor() {
                         }
                     }
                     setOnError {
+                        errorListener?.onError(this.error?.message)
                         println("Gadulka JVM: Error occurred: ${this.error?.message}")
                     }
                 }
             } catch (e: Exception) {
+                errorListener?.onError(e.message)
                 println("Gadulka JVM: Failed to play audio.")
                 e.printStackTrace()
             }
@@ -131,5 +134,9 @@ actual class GadulkaPlayer actual constructor() {
         Platform.runLater {
             playerState?.seek(Duration.millis(time.toDouble()))
         }
+    }
+
+    actual fun setOnErrorListener(listener: ErrorListener) {
+        errorListener = listener
     }
 }

--- a/gadulka/src/wasmJsMain/kotlin/GadulkaAudioPlayer.wasmJs.kt
+++ b/gadulka/src/wasmJsMain/kotlin/GadulkaAudioPlayer.wasmJs.kt
@@ -21,6 +21,7 @@ actual class GadulkaPlayer actual constructor() {
     private val events = mutableListOf<() -> Unit>()
     private var lastVolume: Double? = null
     private var lastRate: Double? = null
+    private var errorListener: ErrorListener? = null
 
     private fun attachEventListeners(el: HTMLAudioElement) {
         detachEventListeners()
@@ -31,6 +32,7 @@ actual class GadulkaPlayer actual constructor() {
         val onEnded: (Event) -> Unit = { _state = GadulkaPlayerState.IDLE }
         val onWaiting: (Event) -> Unit = { _state = GadulkaPlayerState.BUFFERING }
         val onStalled: (Event) -> Unit = { _state = GadulkaPlayerState.BUFFERING }
+        val onError: (Event) -> Unit = { errorListener?.onError(null) }
 
         el.addEventListener("playing", onPlaying)
         events += { el.removeEventListener("playing", onPlaying) }
@@ -44,6 +46,8 @@ actual class GadulkaPlayer actual constructor() {
         events += { el.removeEventListener("waiting", onWaiting) }
         el.addEventListener("stalled", onStalled)
         events += { el.removeEventListener("stalled", onStalled) }
+        el.addEventListener("error", onError)
+        events += { el.removeEventListener("error", onError) }
     }
 
     private fun detachEventListeners() {
@@ -144,5 +148,9 @@ actual class GadulkaPlayer actual constructor() {
     actual fun seekTo(time: Long) {
         // https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/currentTime
         getPlayerElement()?.currentTime = time.toDouble() / 1000.0
+    }
+
+    actual fun setOnErrorListener(listener: ErrorListener) {
+        errorListener = listener
     }
 }


### PR DESCRIPTION
## What?
Added an error listener 

## Why?
To be able to do a certain task on error

## How?
By adding a method that accepts an interface instance that invokes the error to the user

## Testing?
Tested on Android, Windows desktop and browser
NOT TESTED ON iOS