### PR TITLE
Change JavaFX dependencies from implementation to compileOnly

### DIFF
--- a/gadulka/build.gradle.kts
+++ b/gadulka/build.gradle.kts
@@ -65,12 +65,12 @@ kotlin {
                     "osx-aarch_64" -> "mac-aarch64"
                     else -> throw IllegalStateException("Unknown OS: ${osdetector.classifier}")
                 }
-                implementation("org.openjfx:javafx-base:23:${fxSuffix}")
-                implementation("org.openjfx:javafx-graphics:23:${fxSuffix}")
-                implementation("org.openjfx:javafx-controls:23:${fxSuffix}")
-                implementation("org.openjfx:javafx-swing:23:${fxSuffix}")
-                implementation("org.openjfx:javafx-web:23:${fxSuffix}")
-                implementation("org.openjfx:javafx-media:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-base:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-graphics:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-controls:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-swing:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-web:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-media:23:${fxSuffix}")
             }
         }
 

--- a/gadulka/build.gradle.kts
+++ b/gadulka/build.gradle.kts
@@ -65,12 +65,10 @@ kotlin {
                     "osx-aarch_64" -> "mac-aarch64"
                     else -> throw IllegalStateException("Unknown OS: ${osdetector.classifier}")
                 }
-                compileOnly("org.openjfx:javafx-base:23:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-graphics:23:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-controls:23:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-swing:23:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-web:23:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-media:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-base:${JavaVersion.current().majorVersion}:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-graphics:${JavaVersion.current().majorVersion}:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-swing:${JavaVersion.current().majorVersion}:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-media:${JavaVersion.current().majorVersion}:${fxSuffix}")
             }
         }
 

--- a/gadulka/build.gradle.kts
+++ b/gadulka/build.gradle.kts
@@ -65,10 +65,10 @@ kotlin {
                     "osx-aarch_64" -> "mac-aarch64"
                     else -> throw IllegalStateException("Unknown OS: ${osdetector.classifier}")
                 }
-                compileOnly("org.openjfx:javafx-base:${JavaVersion.current().majorVersion}:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-graphics:${JavaVersion.current().majorVersion}:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-swing:${JavaVersion.current().majorVersion}:${fxSuffix}")
-                compileOnly("org.openjfx:javafx-media:${JavaVersion.current().majorVersion}:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-base:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-graphics:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-swing:23:${fxSuffix}")
+                compileOnly("org.openjfx:javafx-media:23:${fxSuffix}")
             }
         }
 


### PR DESCRIPTION
Since your library was published using a Mac system, the org.openjfx:javafx-base:23:mac-aarch64 dependency will be hardcoded into the final published product. After referencing your library and packaging on a Windows system, I found the Mac version of JavaFX. I have ruled out other possible reasons and suggest that you can remove the direct reference to JavaFX and only use it for compiling actual dependencies, which should be manually set by the referencing party. Additionally, regarding the org.openjfx:javafx-web dependency, which exceeds 30MB, is it possible to consider removing it, including using the org.openjfx:javafx-web declared in the documentation, or recommending a minimal scope dependency